### PR TITLE
Update to vib v1.0.2

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v1.0.1
+    - uses: nisel11/vib-gh-action@bump-v1.0.2
       with:
         recipe: 'recipe.yml'
         plugins: 'Vanilla-OS/vib-fsguard:v1.5.3'

--- a/recipe.yml
+++ b/recipe.yml
@@ -1,11 +1,11 @@
 name: Kanola Plasma Desktop
 id: kanola-plasma
-vibversion: 1.0.1
+vibversion: 1.0.2
 
 stages:
 - id: build
   base: ghcr.io/kanola-images/base:main
-  singlelayer: false
+  addincludes: true
   labels:
     maintainer: Kanola Contributors
   args:
@@ -31,8 +31,8 @@ stages:
         url: https://github.com/Vanilla-OS/vanilla-tools/releases/download/continuous/vanilla-tools.tar.gz
     commands:
     - mkdir -p /usr/bin
-    - cp /sources/vanilla-tools/vanilla-tools/lpkg /usr/bin/lpkg
-    - cp /sources/vanilla-tools/vanilla-tools/cur-gpu /usr/bin/cur-gpu
+    - cp /sources/vanilla-tools/vanilla-tools/vanilla-tools/lpkg /usr/bin/lpkg
+    - cp /sources/vanilla-tools/vanilla-tools/vanilla-tools/cur-gpu /usr/bin/cur-gpu
     - chmod +x /usr/bin/lpkg
     - chmod +x /usr/bin/cur-gpu
 


### PR DESCRIPTION
Tested [here](https://github.com/nisel11/Kanola/actions/runs/14601748401)
If my PR in vib-gh-action is accepted, I will update this PR to use vanilla-os/vib-gh-action@v1.0.2 instead of nisel11/vib-gh-action@bump-v1.0.2